### PR TITLE
Update web app download links

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,13 +391,21 @@
                   </svg>
                   <span id="downloadWindows" data-i18n-key="downloadWindows">دانلود نسخه ویندوز</span>
                 </a>
-                <a href="https://www.zoomit.ir/mobile-learning/20984-how-to-add-website-links/" target="_blank" rel="noopener" id="dlWeb" class="dl-item" role="menuitem">
+                <a href="https://pixelarchitecturestudio.github.io/ScaleConverter/" target="_blank" rel="noopener" id="dlWeb" class="dl-item" role="menuitem">
                   <svg class="dl-ic" viewBox="0 0 24 24" aria-hidden="true">
                     <rect x="7" y="2" width="10" height="20" rx="3" fill="none" stroke="currentColor" stroke-width="1.6"/>
                     <path d="M10 4.5h4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
                     <path d="M9 19.5h6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
                   </svg>
                   <span id="downloadWeb" data-i18n-key="downloadWeb">نسخه وب اپ</span>
+                </a>
+                <a href="https://www.zoomit.ir/mobile-learning/20984-how-to-add-website-links/" target="_blank" rel="noopener" id="dlWebHelp" class="dl-item" role="menuitem">
+                  <svg class="dl-ic" viewBox="0 0 24 24" aria-hidden="true">
+                    <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                    <path d="M12 6a3 3 0 00-3 3h2a1 1 0 112 0c0 .5-.2.8-.7 1.1l-.6.4c-.9.6-1.2 1.3-1.2 2.5v.5h2v-.5c0-.6.1-.8.7-1.2l.6-.4A3 3 0 0015 9a3 3 0 00-3-3z" fill="currentColor"/>
+                    <circle cx="12" cy="17" r="1" fill="currentColor"/>
+                  </svg>
+                  <span id="downloadWebHelp" data-i18n-key="downloadWebHelp">آموزش نصب نسخه وب اپ</span>
                 </a>
               </div>
             </span>
@@ -473,6 +481,7 @@
     const downloadLabel = el('downloadLabel');
     const downloadWindows = el('downloadWindows');
     const downloadWeb = el('downloadWeb');
+    const downloadWebHelp = el('downloadWebHelp');
     const versionTitle = el('versionTitle');
     const versionLabel = el('versionLabel');
     const versionChangesLabel = el('versionChangesLabel');
@@ -508,6 +517,7 @@
         downloadAria: 'دانلود',
         downloadWindows: 'دانلود نسخه ویندوز',
         downloadWeb: 'نسخه وب اپ',
+        downloadWebHelp: 'آموزش نصب نسخه وب اپ',
         versionTitle: 'نرم‌افزار تبدیل مقیاس',
         versionLabel: 'نسخه',
         versionChangesLabel: 'آخرین تغییرات',
@@ -568,6 +578,7 @@
         downloadAria: 'Download',
         downloadWindows: 'Download Windows version',
         downloadWeb: 'Web app version',
+        downloadWebHelp: 'Web app install guide',
         versionTitle: 'Scale Converter App',
         versionLabel: 'Version',
         versionChangesLabel: 'Latest changes',
@@ -750,6 +761,7 @@
       if (downloadLabel) downloadLabel.textContent = locale.downloadLabel;
       if (downloadWindows) downloadWindows.textContent = locale.downloadWindows;
       if (downloadWeb) downloadWeb.textContent = locale.downloadWeb;
+      if (downloadWebHelp) downloadWebHelp.textContent = locale.downloadWebHelp;
       if (dlBtn) dlBtn.setAttribute('title', locale.downloadTitle);
       if (dlPop) dlPop.setAttribute('aria-label', locale.downloadAria);
       if (converterForm) converterForm.setAttribute('aria-label', locale.formAriaLabel);

--- a/index.html
+++ b/index.html
@@ -768,16 +768,34 @@
       if (dlBtn) dlBtn.setAttribute('title', locale.downloadTitle);
       if (dlPop) dlPop.setAttribute('aria-label', locale.downloadAria);
       if (converterForm) converterForm.setAttribute('aria-label', locale.formAriaLabel);
-      if (versionTitle) versionTitle.textContent = locale.versionTitle;
-      if (versionLabel) versionLabel.textContent = locale.versionLabel;
-      if (versionChangesLabel) versionChangesLabel.textContent = locale.versionChangesLabel;
-      if (versionChanges) versionChanges.textContent = locale.versionChanges;
-      if (versionHint) versionHint.textContent = locale.versionHint;
+      const isEnglish = locale.code === 'en';
+      if (versionTitle){
+        versionTitle.textContent = locale.versionTitle;
+        versionTitle.classList.toggle('ltr', isEnglish);
+      }
+      if (versionLabel){
+        versionLabel.textContent = locale.versionLabel;
+        const labelRow = versionLabel.parentElement;
+        if (labelRow) labelRow.classList.toggle('ltr', isEnglish);
+      }
+      if (versionChangesLabel){
+        versionChangesLabel.textContent = locale.versionChangesLabel;
+        versionChangesLabel.classList.toggle('ltr', isEnglish);
+      }
+      if (versionChanges){
+        versionChanges.textContent = locale.versionChanges;
+        versionChanges.classList.toggle('ltr', isEnglish);
+      }
+      if (versionHint){
+        versionHint.textContent = locale.versionHint;
+        versionHint.classList.toggle('ltr', isEnglish);
+      }
+      if (verPop) verPop.classList.toggle('ltr', isEnglish);
       if (versionBtn) versionBtn.setAttribute('title', locale.versionBtnTitle);
       if (verPop) verPop.setAttribute('aria-label', locale.versionBtnTitle);
       if (footnote){
         footnote.innerHTML = locale.footnote;
-        footnote.classList.toggle('ltr', locale.code === 'en');
+        footnote.classList.toggle('ltr', isEnglish);
       }
       if (histPop) histPop.setAttribute('aria-label', locale.histDialogLabel);
       if (histHead) histHead.textContent = locale.histTitle;

--- a/index.html
+++ b/index.html
@@ -739,7 +739,10 @@
       document.documentElement.dir = locale.dir || 'rtl';
       if (document.title !== locale.pageTitle) document.title = locale.pageTitle;
       if (pageHeading) pageHeading.textContent = locale.heading;
-      if (descriptionEl) descriptionEl.innerHTML = locale.description;
+      if (descriptionEl){
+        descriptionEl.innerHTML = locale.description;
+        descriptionEl.classList.toggle('ltr', locale.code === 'en');
+      }
       if (realUnitLabel) realUnitLabel.textContent = locale.realUnitLabel;
       if (scaleSelectLabel) scaleSelectLabel.textContent = locale.scaleSelectLabel;
       if (targetUnitLabel) targetUnitLabel.textContent = locale.targetUnitLabel;
@@ -772,7 +775,10 @@
       if (versionHint) versionHint.textContent = locale.versionHint;
       if (versionBtn) versionBtn.setAttribute('title', locale.versionBtnTitle);
       if (verPop) verPop.setAttribute('aria-label', locale.versionBtnTitle);
-      if (footnote) footnote.innerHTML = locale.footnote;
+      if (footnote){
+        footnote.innerHTML = locale.footnote;
+        footnote.classList.toggle('ltr', locale.code === 'en');
+      }
       if (histPop) histPop.setAttribute('aria-label', locale.histDialogLabel);
       if (histHead) histHead.textContent = locale.histTitle;
       if (histClose) histClose.setAttribute('aria-label', locale.histCloseLabel);


### PR DESCRIPTION
## Summary
- point the web app download option to the live Scale Converter deployment
- add a new help entry in the download menu linking to the existing installation guide with a help icon
- localize the new menu label for both Persian and English interfaces

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e198a647ac832893426e4ab42e0734