### PR TITLE
Update news popover placeholder copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,8 +336,21 @@
           <span class="lang-text" id="langToggleText">فا</span>
         </button>
         <div class="news-anchor">
-          <button id="newsBtn" class="icon-btn news-btn" type="button" aria-haspopup="dialog" aria-expanded="false" title="News">
-            <img src="news-icon.svg" alt="" class="news-icon" aria-hidden="true" />
+          <button id="newsBtn" class="icon-btn news-btn" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="newsPop" title="News">
+            <svg class="news-icon" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+              <defs>
+                <linearGradient id="newsIconGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#5c2aff" />
+                  <stop offset="100%" stop-color="#a855f7" />
+                </linearGradient>
+              </defs>
+              <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#newsIconGradient)" />
+              <rect x="14" y="16" width="36" height="6" rx="3" fill="rgba(255,255,255,0.75)" />
+              <rect x="14" y="26" width="22" height="6" rx="3" fill="rgba(255,255,255,0.85)" />
+              <rect x="14" y="36" width="28" height="6" rx="3" fill="rgba(255,255,255,0.65)" />
+              <rect x="14" y="46" width="18" height="6" rx="3" fill="rgba(255,255,255,0.5)" />
+              <path d="M42 31l8-7v18l-8-7v-4z" fill="#f1f5ff" />
+            </svg>
           </button>
           <div id="newsPop" class="news-pop hidden" role="dialog" aria-label="News">
             <div class="news-head">

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
     .news-body{font-size:13px;color:var(--text);white-space:pre-line}
 
     @media (max-width:680px){
-      .news-anchor{position:static}
+      .news-anchor{position:relative}
       .news-pop{top:calc(100% + 8px);left:50%;transform:translate(-50%,0);right:auto}
     }
     .lang-btn{min-width:60px;position:relative;cursor:pointer;border:1px solid #2b3152;background:#0f1326;color:var(--text);border-radius:999px;display:inline-flex;align-items:center;justify-content:center;height:28px;padding:0 14px;font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase}

--- a/index.html
+++ b/index.html
@@ -345,11 +345,12 @@
                 </linearGradient>
               </defs>
               <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#newsIconGradient)" />
-              <rect x="14" y="16" width="36" height="6" rx="3" fill="rgba(255,255,255,0.75)" />
-              <rect x="14" y="26" width="22" height="6" rx="3" fill="rgba(255,255,255,0.85)" />
-              <rect x="14" y="36" width="28" height="6" rx="3" fill="rgba(255,255,255,0.65)" />
-              <rect x="14" y="46" width="18" height="6" rx="3" fill="rgba(255,255,255,0.5)" />
-              <path d="M42 31l8-7v18l-8-7v-4z" fill="#f1f5ff" />
+              <path d="M18 28l20-10v28L18 36v-8z" fill="rgba(255,255,255,0.88)" />
+              <path d="M18 36h-4c-1.1 0-2 .9-2 2v10h6z" fill="rgba(219,229,255,0.9)" />
+              <rect x="30" y="24" width="4" height="24" rx="2" fill="rgba(15,19,38,0.35)" />
+              <path d="M44 24c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2h-2V24h2z" fill="rgba(255,255,255,0.85)" />
+              <path d="M48 26c2.2 1.8 3.5 4.4 3.5 7s-1.3 5.2-3.5 7" fill="none" stroke="rgba(255,255,255,0.75)" stroke-width="3" stroke-linecap="round" />
+              <path d="M52 24c2.8 2.6 4.5 6.3 4.5 9.9S54.8 41.2 52 44" fill="none" stroke="rgba(255,255,255,0.45)" stroke-width="3" stroke-linecap="round" />
             </svg>
           </button>
           <div id="newsPop" class="news-pop hidden" role="dialog" aria-label="News">

--- a/index.html
+++ b/index.html
@@ -582,7 +582,10 @@ Check back later for updates.</div>
     const newsTitle = el('newsTitle');
     const newsBody = el('newsBody');
     const newsClose = el('newsClose');
-    const NEWS_SOURCE = 'news.txt';
+    const NEWS_SOURCES = [
+      'https://raw.githubusercontent.com/PixelArchitectureStudio/ScaleConverter/main/news.txt',
+      'news.txt'
+    ];
     let newsContentOverride = null;
     let newsFetchPromise = null;
 
@@ -1224,29 +1227,43 @@ Check back later for updates.</div>
       setNewsBody(locale.newsLoading, true);
       requestAnimationFrame(positionNewsPopover);
       const cacheBuster = Date.now().toString(36);
-      newsFetchPromise = fetch(`${NEWS_SOURCE}?v=${cacheBuster}`, { cache: 'no-store' })
-        .then(async function(res){
-          if (!res.ok){
-            if (res.status === 404) return null;
-            throw new Error(`News fetch failed: ${res.status}`);
-          }
-          const text = (await res.text()).replace(/\r\n/g, '\n').trim();
-          return text.length ? text : null;
-        })
+      function fetchFromSource(index){
+        if (index >= NEWS_SOURCES.length) return Promise.reject(new Error('News unavailable'));
+        const src = NEWS_SOURCES[index];
+        const separator = src.includes('?') ? '&' : '?';
+        return fetch(`${src}${separator}v=${cacheBuster}`, { cache: 'no-store' })
+          .then(async function(res){
+            if (!res.ok){
+              const error = new Error(`News fetch failed: ${res.status}`);
+              error.status = res.status;
+              throw error;
+            }
+            const text = (await res.text()).replace(/\r\n/g, '\n').trim();
+            if (text.length) return text;
+            const emptyError = new Error('News empty');
+            emptyError.code = 'empty';
+            throw emptyError;
+          })
+          .catch(function(err){
+            if (index < NEWS_SOURCES.length - 1){
+              console.warn(err);
+              return fetchFromSource(index + 1);
+            }
+            throw err;
+          });
+      }
+      newsFetchPromise = fetchFromSource(0)
         .then(function(content){
-          const activeLocale = getLocale();
-          if (content){
-            newsContentOverride = content;
-            setNewsBody(content, false);
-          } else {
-            newsContentOverride = null;
-            setNewsBody(activeLocale.newsEmpty, false);
-          }
+          newsContentOverride = content;
+          setNewsBody(content, false);
           requestAnimationFrame(positionNewsPopover);
         })
         .catch(function(err){
           console.warn(err);
           const activeLocale = getLocale();
+          if (err && (err.code === 'empty' || err.status === 404)){
+            newsContentOverride = null;
+          }
           if (newsContentOverride){
             setNewsBody(newsContentOverride, false);
           } else {

--- a/index.html
+++ b/index.html
@@ -554,6 +554,7 @@ Check back later for updates.</div>
     const unitToMM = { mm:1, cm:10, m:1000, km:1000000, in:25.4, ft:304.8, yd:914.4, mi:1609344, nmi:1852000 };
     const APP_VERSION = '1.4';
     const APP_URL = 'https://pixelarchitecturestudio.github.io/ScaleConverter/';
+    const DEFAULT_WINDOWS_URL = 'https://github.com/PixelArchitectureStudio/ScaleConverter/releases/download/v1.4/ScaleConverter_Win64.exe';
     const el = (id) => document.getElementById(id);
 
     const realUnit = el('realUnit');
@@ -601,6 +602,12 @@ Check back later for updates.</div>
     const dlBtn = el('dlBtn');
     const dlPop = el('dlPop');
     const dlWin = el('dlWin');
+    const WINDOWS_LINK_SOURCES = [
+      'https://raw.githubusercontent.com/PixelArchitectureStudio/ScaleConverter/main/windows.txt',
+      'windows.txt'
+    ];
+    let windowsLinkOverride = null;
+    let windowsFetchPromise = null;
     const dlWebLink = el('dlWeb');
     const dlShareBtn = el('dlShareBtn');
     const langToggle = el('langToggle');
@@ -1178,7 +1185,67 @@ Check back later for updates.</div>
     if (histClose){ histClose.addEventListener('click', function(e){ e.stopPropagation(); toggleHistory(false); }); }
     function toggleVersion(show){ if (!verPop || !versionBtn) return; const open = !verPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('version'); verPop.classList.remove('hidden'); versionBtn.setAttribute('aria-expanded','true'); } else { verPop.classList.add('hidden'); versionBtn.setAttribute('aria-expanded','false'); } }
     if (versionBtn){ versionBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleVersion(); }); }
-    function toggleDownload(show){ if (!dlPop || !dlBtn) return; const open = !dlPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('download'); dlPop.classList.remove('hidden'); dlBtn.setAttribute('aria-expanded','true'); } else { dlPop.classList.add('hidden'); dlBtn.setAttribute('aria-expanded','false'); } }
+    function applyWindowsLink(url){
+      if (!dlWin) return;
+      const value = (typeof url === 'string' && url.trim().length) ? url.trim() : DEFAULT_WINDOWS_URL;
+      dlWin.setAttribute('href', value);
+    }
+    applyWindowsLink(DEFAULT_WINDOWS_URL);
+    function ensureWindowsLink(){
+      if (!dlWin) return Promise.resolve();
+      if (windowsFetchPromise) return windowsFetchPromise;
+      if (typeof fetch !== 'function'){
+        applyWindowsLink(windowsLinkOverride);
+        return Promise.resolve();
+      }
+      const cacheBuster = Date.now().toString(36);
+      function fetchWindowsFromSource(index){
+        if (index >= WINDOWS_LINK_SOURCES.length) return Promise.reject(new Error('Windows link unavailable'));
+        const src = WINDOWS_LINK_SOURCES[index];
+        const separator = src.includes('?') ? '&' : '?';
+        return fetch(`${src}${separator}v=${cacheBuster}`, { cache: 'no-store' })
+          .then(async function(res){
+            if (!res.ok){
+              const error = new Error(`Windows link fetch failed: ${res.status}`);
+              error.status = res.status;
+              throw error;
+            }
+            const text = (await res.text()).replace(/\r\n/g, '\n').trim();
+            if (text.length) return text;
+            const emptyError = new Error('Windows link empty');
+            emptyError.code = 'empty';
+            throw emptyError;
+          })
+          .catch(function(err){
+            if (index < WINDOWS_LINK_SOURCES.length - 1){
+              console.warn(err);
+              return fetchWindowsFromSource(index + 1);
+            }
+            throw err;
+          });
+      }
+      windowsFetchPromise = fetchWindowsFromSource(0)
+        .then(function(link){
+          windowsLinkOverride = typeof link === 'string' ? link.trim() : link;
+          applyWindowsLink(windowsLinkOverride);
+        })
+        .catch(function(err){
+          console.warn(err);
+          if (err && (err.code === 'empty' || err.status === 404)){
+            windowsLinkOverride = null;
+          }
+          if (windowsLinkOverride){
+            applyWindowsLink(windowsLinkOverride);
+          } else {
+            applyWindowsLink(null);
+          }
+        })
+        .finally(function(){
+          windowsFetchPromise = null;
+        });
+      return windowsFetchPromise;
+    }
+    function toggleDownload(show){ if (!dlPop || !dlBtn) return; const open = !dlPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('download'); dlPop.classList.remove('hidden'); dlBtn.setAttribute('aria-expanded','true'); ensureWindowsLink(); } else { dlPop.classList.add('hidden'); dlBtn.setAttribute('aria-expanded','false'); } }
     function positionNewsPopover(){
       if (!newsPop || !newsBtn || newsPop.classList.contains('hidden')) return;
       const gapX = 12;

--- a/index.html
+++ b/index.html
@@ -337,13 +337,10 @@
         </button>
         <div class="news-anchor">
           <button id="newsBtn" class="icon-btn news-btn" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="newsPop" title="News">
-            <svg class="news-icon" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
-              <rect x="4" y="4" width="56" height="56" rx="12" fill="#1c2743" />
-              <path d="M20 26h14l14-8v28l-14-8H20z" fill="#9dd2ff" />
-              <path d="M34 26h4v20h-4z" fill="#7aa2ff" />
-              <path d="M18 34c-2.2 0-4 1.8-4 4v10h6l2-6v-8h-4z" fill="#d2e5ff" />
-              <path d="M48 26c2.4 1.6 4 4.6 4 8s-1.6 6.4-4 8" fill="none" stroke="#9dd2ff" stroke-width="3" stroke-linecap="round" />
-              <path d="M52 22c3.6 2.8 6 7.4 6 12s-2.4 9.2-6 12" fill="none" stroke="#7aa2ff" stroke-width="3" stroke-linecap="round" />
+            <svg class="news-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M4 11.5v1.8c0 1.2.9 2.2 2 2.2h1.6l2.4 3.8V7.7L7.6 11H6c-1.1 0-2 .9-2 2z" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linejoin="round" stroke-linecap="round" />
+              <path d="M10 8.5l10-2.2v11.4L10 15.5z" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linejoin="round" stroke-linecap="round" />
+              <path d="M21.5 8.5c1.5 1.5 1.5 5.5 0 7" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
             </svg>
           </button>
           <div id="newsPop" class="news-pop hidden" role="dialog" aria-label="News">

--- a/index.html
+++ b/index.html
@@ -643,6 +643,32 @@ Check back later for updates.</div>
         return trimmed;
       }
     }
+    function buildTextFetchRequest(src, cacheBuster){
+      if (!src || typeof src !== 'string') return { url: src, options: undefined };
+      const trimmed = src.trim();
+      if (!trimmed) return { url: trimmed, options: undefined };
+      let urlString = trimmed;
+      let fetchOptions;
+      try {
+        const parsed = new URL(trimmed, window.location.href);
+        const protocol = parsed.protocol ? parsed.protocol.toLowerCase() : '';
+        const isHttp = protocol === 'http:' || protocol === 'https:';
+        if (isHttp && cacheBuster){
+          parsed.searchParams.set('v', cacheBuster);
+        }
+        urlString = parsed.toString();
+        if (isHttp){
+          fetchOptions = { cache: 'no-store' };
+        }
+      } catch(err){
+        if (cacheBuster && /^https?:/i.test(trimmed)){
+          const separator = trimmed.includes('?') ? '&' : '?';
+          urlString = `${trimmed}${separator}v=${cacheBuster}`;
+          fetchOptions = { cache: 'no-store' };
+        }
+      }
+      return { url: urlString, options: fetchOptions };
+    }
     const dlWebLink = el('dlWeb');
     const dlShareBtn = el('dlShareBtn');
     const langToggle = el('langToggle');
@@ -1239,8 +1265,8 @@ Check back later for updates.</div>
         const src = WINDOWS_LINK_SOURCES[index];
         const normalizedSrc = normalizeRemoteTextSource(src) || src;
         const urlToFetch = typeof normalizedSrc === 'string' ? normalizedSrc : String(normalizedSrc || '');
-        const separator = urlToFetch.includes('?') ? '&' : '?';
-        return fetch(`${urlToFetch}${separator}v=${cacheBuster}`, { cache: 'no-store' })
+        const request = buildTextFetchRequest(urlToFetch, cacheBuster);
+        return fetch(request.url, request.options)
           .then(async function(res){
             if (!res.ok){
               const error = new Error(`Windows link fetch failed: ${res.status}`);
@@ -1336,8 +1362,8 @@ Check back later for updates.</div>
         const src = NEWS_SOURCES[index];
         const normalizedSrc = normalizeRemoteTextSource(src) || src;
         const urlToFetch = typeof normalizedSrc === 'string' ? normalizedSrc : String(normalizedSrc || '');
-        const separator = urlToFetch.includes('?') ? '&' : '?';
-        return fetch(`${urlToFetch}${separator}v=${cacheBuster}`, { cache: 'no-store' })
+        const request = buildTextFetchRequest(urlToFetch, cacheBuster);
+        return fetch(request.url, request.options)
           .then(async function(res){
             if (!res.ok){
               const error = new Error(`News fetch failed: ${res.status}`);

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
     .news-btn{cursor:pointer;border:1px solid #2b3152;background:#0f1326;color:var(--text);border-radius:10px;width:32px;height:32px;padding:0;display:inline-flex;align-items:center;justify-content:center}
     .news-btn:hover{filter:brightness(1.1)}
     .news-icon{width:18px;height:18px;display:block}
-    .news-pop{position:fixed;top:72px;left:50%;transform:translateX(-50%);background:#0f1326;border:1px solid #2b3152;border-radius:12px;width:240px;max-width:min(320px,calc(100vw - 48px));padding:16px;box-shadow:0 10px 30px rgba(0,0,0,.35);z-index:90}
+    .news-pop{position:fixed;top:0;left:0;transform:none;background:#0f1326;border:1px solid #2b3152;border-radius:12px;width:240px;max-width:min(320px,calc(100vw - 48px));padding:16px;box-shadow:0 10px 30px rgba(0,0,0,.35);z-index:90}
     .news-pop.hidden{display:none}
     .news-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;font-size:12px;color:#94a3c7}
     .news-title{font-weight:600;letter-spacing:.02em}
@@ -1153,9 +1153,38 @@ Check back later for updates.</div>
     function toggleVersion(show){ if (!verPop || !versionBtn) return; const open = !verPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('version'); verPop.classList.remove('hidden'); versionBtn.setAttribute('aria-expanded','true'); } else { verPop.classList.add('hidden'); versionBtn.setAttribute('aria-expanded','false'); } }
     if (versionBtn){ versionBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleVersion(); }); }
     function toggleDownload(show){ if (!dlPop || !dlBtn) return; const open = !dlPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('download'); dlPop.classList.remove('hidden'); dlBtn.setAttribute('aria-expanded','true'); } else { dlPop.classList.add('hidden'); dlBtn.setAttribute('aria-expanded','false'); } }
-    function positionNewsPopover(){ if (!newsPop || !newsBtn || newsPop.classList.contains('hidden')) return; const gap = 12; const btnRect = newsBtn.getBoundingClientRect(); const popRect = newsPop.getBoundingClientRect(); const vw = window.innerWidth; const vh = window.innerHeight; let top = btnRect.top + (btnRect.height / 2) - (popRect.height / 2); top = Math.max(16, Math.min(top, vh - popRect.height - 16)); let left = btnRect.right + gap; if (left + popRect.width + 16 > vw){ left = btnRect.left - gap - popRect.width; }
-      if (left < 16){ left = Math.max(16, Math.min(vw - popRect.width - 16, btnRect.left + (btnRect.width / 2) - (popRect.width / 2))); top = btnRect.bottom + gap; top = Math.max(16, Math.min(top, vh - popRect.height - 16)); }
-      newsPop.style.top = `${top}px`; newsPop.style.left = `${left}px`; newsPop.style.right = 'auto'; newsPop.style.transform = 'none'; }
+    function positionNewsPopover(){
+      if (!newsPop || !newsBtn || newsPop.classList.contains('hidden')) return;
+      const gapX = 12;
+      const gapY = 12;
+      const padding = 16;
+      const btnRect = newsBtn.getBoundingClientRect();
+      const popRect = newsPop.getBoundingClientRect();
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+
+      let left = btnRect.right + gapX;
+      let top = btnRect.bottom + gapY;
+
+      if (left + popRect.width + padding > vw){
+        left = btnRect.left - gapX - popRect.width;
+      }
+      if (left < padding){
+        left = Math.max(padding, Math.min(vw - popRect.width - padding, btnRect.left + btnRect.width - popRect.width));
+      }
+
+      if (top + popRect.height + padding > vh){
+        top = btnRect.top - gapY - popRect.height;
+      }
+      if (top < padding){
+        top = Math.max(padding, Math.min(vh - popRect.height - padding, btnRect.bottom - popRect.height));
+      }
+
+      newsPop.style.left = `${Math.max(padding, Math.min(left, vw - popRect.width - padding))}px`;
+      newsPop.style.top = `${Math.max(padding, Math.min(top, vh - popRect.height - padding))}px`;
+      newsPop.style.right = 'auto';
+      newsPop.style.transform = 'none';
+    }
     function toggleNews(show){ if (!newsPop || !newsBtn) return; const open = !newsPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('news'); newsPop.classList.remove('hidden'); newsBtn.setAttribute('aria-expanded','true'); requestAnimationFrame(positionNewsPopover); } else { newsPop.classList.add('hidden'); newsBtn.setAttribute('aria-expanded','false'); newsPop.style.top=''; newsPop.style.left=''; newsPop.style.right=''; newsPop.style.transform=''; } }
     if (newsBtn){ newsBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleNews(); }); }
     if (newsClose){ newsClose.addEventListener('click', function(e){ e.stopPropagation(); toggleNews(false); }); }

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
     .news-btn{cursor:pointer;border:1px solid #2b3152;background:#0f1326;color:var(--text);border-radius:10px;width:32px;height:32px;padding:0;display:inline-flex;align-items:center;justify-content:center}
     .news-btn:hover{filter:brightness(1.1)}
     .news-icon{width:18px;height:18px;display:block}
-    .news-pop{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:#0f1326;border:1px solid #2b3152;border-radius:12px;width:240px;max-width:min(320px,calc(100vw - 48px));padding:16px;box-shadow:0 10px 30px rgba(0,0,0,.35);z-index:90}
+    .news-pop{position:fixed;top:72px;left:50%;transform:translateX(-50%);background:#0f1326;border:1px solid #2b3152;border-radius:12px;width:240px;max-width:min(320px,calc(100vw - 48px));padding:16px;box-shadow:0 10px 30px rgba(0,0,0,.35);z-index:90}
     .news-pop.hidden{display:none}
     .news-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;font-size:12px;color:#94a3c7}
     .news-title{font-weight:600;letter-spacing:.02em}
@@ -1153,9 +1153,15 @@ Check back later for updates.</div>
     function toggleVersion(show){ if (!verPop || !versionBtn) return; const open = !verPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('version'); verPop.classList.remove('hidden'); versionBtn.setAttribute('aria-expanded','true'); } else { verPop.classList.add('hidden'); versionBtn.setAttribute('aria-expanded','false'); } }
     if (versionBtn){ versionBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleVersion(); }); }
     function toggleDownload(show){ if (!dlPop || !dlBtn) return; const open = !dlPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('download'); dlPop.classList.remove('hidden'); dlBtn.setAttribute('aria-expanded','true'); } else { dlPop.classList.add('hidden'); dlBtn.setAttribute('aria-expanded','false'); } }
-    function toggleNews(show){ if (!newsPop || !newsBtn) return; const open = !newsPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('news'); newsPop.classList.remove('hidden'); newsBtn.setAttribute('aria-expanded','true'); } else { newsPop.classList.add('hidden'); newsBtn.setAttribute('aria-expanded','false'); } }
+    function positionNewsPopover(){ if (!newsPop || !newsBtn || newsPop.classList.contains('hidden')) return; const gap = 12; const btnRect = newsBtn.getBoundingClientRect(); const popRect = newsPop.getBoundingClientRect(); const vw = window.innerWidth; const vh = window.innerHeight; let top = btnRect.top + (btnRect.height / 2) - (popRect.height / 2); top = Math.max(16, Math.min(top, vh - popRect.height - 16)); let left = btnRect.right + gap; if (left + popRect.width + 16 > vw){ left = btnRect.left - gap - popRect.width; }
+      if (left < 16){ left = Math.max(16, Math.min(vw - popRect.width - 16, btnRect.left + (btnRect.width / 2) - (popRect.width / 2))); top = btnRect.bottom + gap; top = Math.max(16, Math.min(top, vh - popRect.height - 16)); }
+      newsPop.style.top = `${top}px`; newsPop.style.left = `${left}px`; newsPop.style.right = 'auto'; newsPop.style.transform = 'none'; }
+    function toggleNews(show){ if (!newsPop || !newsBtn) return; const open = !newsPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('news'); newsPop.classList.remove('hidden'); newsBtn.setAttribute('aria-expanded','true'); requestAnimationFrame(positionNewsPopover); } else { newsPop.classList.add('hidden'); newsBtn.setAttribute('aria-expanded','false'); newsPop.style.top=''; newsPop.style.left=''; newsPop.style.right=''; newsPop.style.transform=''; } }
     if (newsBtn){ newsBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleNews(); }); }
     if (newsClose){ newsClose.addEventListener('click', function(e){ e.stopPropagation(); toggleNews(false); }); }
+    window.addEventListener('resize', positionNewsPopover);
+    window.addEventListener('orientationchange', positionNewsPopover);
+    window.addEventListener('scroll', positionNewsPopover, true);
     if (dlBtn){ dlBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleDownload(); }); }
     if (dlWin){
       dlWin.addEventListener('click', function(e){

--- a/index.html
+++ b/index.html
@@ -338,9 +338,14 @@
         <div class="news-anchor">
           <button id="newsBtn" class="icon-btn news-btn" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="newsPop" title="News">
             <svg class="news-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-              <path d="M4 11.5v1.8c0 1.2.9 2.2 2 2.2h1.6l2.4 3.8V7.7L7.6 11H6c-1.1 0-2 .9-2 2z" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linejoin="round" stroke-linecap="round" />
-              <path d="M10 8.5l10-2.2v11.4L10 15.5z" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linejoin="round" stroke-linecap="round" />
-              <path d="M21.5 8.5c1.5 1.5 1.5 5.5 0 7" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
+              <rect x="4.75" y="6.5" width="13.5" height="11.5" rx="1.6" ry="1.6" fill="none" stroke="#7aa2ff" stroke-width="1.6" />
+              <path d="M19.25 8.5h.75c.97 0 1.75.78 1.75 1.75v6.5c0 1.1-.9 2-2 2H18" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+              <path d="M7.5 9.75h4.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
+              <path d="M7.5 12.25h6.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
+              <path d="M7.5 14.75h6.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
+              <path d="M15.75 9.75h1.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
+              <path d="M15.75 12.25h1.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
+              <path d="M15.75 14.75h1.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
             </svg>
           </button>
           <div id="newsPop" class="news-pop hidden" role="dialog" aria-label="News">

--- a/index.html
+++ b/index.html
@@ -338,19 +338,12 @@
         <div class="news-anchor">
           <button id="newsBtn" class="icon-btn news-btn" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="newsPop" title="News">
             <svg class="news-icon" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
-              <defs>
-                <linearGradient id="newsIconGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                  <stop offset="0%" stop-color="#5c2aff" />
-                  <stop offset="100%" stop-color="#a855f7" />
-                </linearGradient>
-              </defs>
-              <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#newsIconGradient)" />
-              <path d="M18 28l20-10v28L18 36v-8z" fill="rgba(255,255,255,0.88)" />
-              <path d="M18 36h-4c-1.1 0-2 .9-2 2v10h6z" fill="rgba(219,229,255,0.9)" />
-              <rect x="30" y="24" width="4" height="24" rx="2" fill="rgba(15,19,38,0.35)" />
-              <path d="M44 24c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2h-2V24h2z" fill="rgba(255,255,255,0.85)" />
-              <path d="M48 26c2.2 1.8 3.5 4.4 3.5 7s-1.3 5.2-3.5 7" fill="none" stroke="rgba(255,255,255,0.75)" stroke-width="3" stroke-linecap="round" />
-              <path d="M52 24c2.8 2.6 4.5 6.3 4.5 9.9S54.8 41.2 52 44" fill="none" stroke="rgba(255,255,255,0.45)" stroke-width="3" stroke-linecap="round" />
+              <rect x="4" y="4" width="56" height="56" rx="12" fill="#1c2743" />
+              <path d="M20 26h14l14-8v28l-14-8H20z" fill="#9dd2ff" />
+              <path d="M34 26h4v20h-4z" fill="#7aa2ff" />
+              <path d="M18 34c-2.2 0-4 1.8-4 4v10h6l2-6v-8h-4z" fill="#d2e5ff" />
+              <path d="M48 26c2.4 1.6 4 4.6 4 8s-1.6 6.4-4 8" fill="none" stroke="#9dd2ff" stroke-width="3" stroke-linecap="round" />
+              <path d="M52 22c3.6 2.8 6 7.4 6 12s-2.4 9.2-6 12" fill="none" stroke="#7aa2ff" stroke-width="3" stroke-linecap="round" />
             </svg>
           </button>
           <div id="newsPop" class="news-pop hidden" role="dialog" aria-label="News">

--- a/index.html
+++ b/index.html
@@ -554,6 +554,7 @@ Check back later for updates.</div>
     const unitToMM = { mm:1, cm:10, m:1000, km:1000000, in:25.4, ft:304.8, yd:914.4, mi:1609344, nmi:1852000 };
     const APP_VERSION = '1.4';
     const APP_URL = 'https://pixelarchitecturestudio.github.io/ScaleConverter/';
+    const SHARE_URL = 'https://pixelarchitecturestudio.github.io/ScaleConverter/';
     const DEFAULT_WINDOWS_URL = 'https://github.com/PixelArchitectureStudio/ScaleConverter/releases/download/v1.4/ScaleConverter_Win64.exe';
     const el = (id) => document.getElementById(id);
 
@@ -1440,7 +1441,8 @@ Check back later for updates.</div>
         e.preventDefault();
         e.stopPropagation();
         const locale = getLocale();
-        const shareData = { title: locale.shareTitle, text: locale.shareText, url: APP_URL };
+        const shareUrl = SHARE_URL || APP_URL;
+        const shareData = { title: locale.shareTitle, text: locale.shareText, url: shareUrl };
         let handled = false;
         if (typeof navigator !== 'undefined' && navigator.share){
           try {
@@ -1452,7 +1454,7 @@ Check back later for updates.</div>
         }
         if (!handled && typeof navigator !== 'undefined' && navigator.clipboard && window.isSecureContext){
           try {
-            await navigator.clipboard.writeText(APP_URL);
+            await navigator.clipboard.writeText(shareUrl);
             alert(locale.shareCopied);
             handled = true;
           } catch(err){
@@ -1461,7 +1463,7 @@ Check back later for updates.</div>
         }
         if (!handled){
           alert(locale.shareFallback);
-          openLinkExternally(APP_URL, {preferSystem:true});
+          openLinkExternally(shareUrl, {preferSystem:true});
         }
         toggleDownload(false);
       });

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
     .news-btn{cursor:pointer;border:1px solid #2b3152;background:#0f1326;color:var(--text);border-radius:10px;width:32px;height:32px;padding:0;display:inline-flex;align-items:center;justify-content:center}
     .news-btn:hover{filter:brightness(1.1)}
     .news-icon{width:18px;height:18px;display:block}
-    .news-pop{position:absolute;top:calc(50% + 16px);left:calc(100% + 12px);right:auto;transform:translateY(-50%);background:#0f1326;border:1px solid #2b3152;border-radius:12px;width:220px;max-width:min(240px,calc(100vw - 48px));padding:12px;box-shadow:0 10px 30px rgba(0,0,0,.35);z-index:90}
+    .news-pop{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:#0f1326;border:1px solid #2b3152;border-radius:12px;width:240px;max-width:min(320px,calc(100vw - 48px));padding:16px;box-shadow:0 10px 30px rgba(0,0,0,.35);z-index:90}
     .news-pop.hidden{display:none}
     .news-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;font-size:12px;color:#94a3c7}
     .news-title{font-weight:600;letter-spacing:.02em}
@@ -112,8 +112,7 @@
     .news-body{font-size:13px;color:var(--text);white-space:pre-line}
 
     @media (max-width:680px){
-      .news-anchor{position:relative}
-      .news-pop{top:calc(100% + 8px);left:50%;transform:translate(-50%,0);right:auto}
+      .news-pop{width:90%;max-width:calc(100vw - 48px)}
     }
     .lang-btn{min-width:60px;position:relative;cursor:pointer;border:1px solid #2b3152;background:#0f1326;color:var(--text);border-radius:999px;display:inline-flex;align-items:center;justify-content:center;height:28px;padding:0 14px;font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase}
     .lang-btn:hover{filter:brightness(1.1)}

--- a/index.html
+++ b/index.html
@@ -603,7 +603,7 @@ Check back later for updates.</div>
     const dlPop = el('dlPop');
     const dlWin = el('dlWin');
     const WINDOWS_LINK_SOURCES = [
-      'https://github.com/PixelArchitectureStudio/ScaleConverter/blob/main/windows.txt',
+      'https://raw.githubusercontent.com/PixelArchitectureStudio/ScaleConverter/main/windows.txt',
       'windows.txt'
     ];
     let windowsLinkOverride = null;

--- a/index.html
+++ b/index.html
@@ -337,15 +337,15 @@
         </button>
         <div class="news-anchor">
           <button id="newsBtn" class="icon-btn news-btn" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="newsPop" title="News">
-            <svg class="news-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-              <rect x="4.75" y="6.5" width="13.5" height="11.5" rx="1.6" ry="1.6" fill="none" stroke="#7aa2ff" stroke-width="1.6" />
-              <path d="M19.25 8.5h.75c.97 0 1.75.78 1.75 1.75v6.5c0 1.1-.9 2-2 2H18" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
-              <path d="M7.5 9.75h4.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
-              <path d="M7.5 12.25h6.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
-              <path d="M7.5 14.75h6.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
-              <path d="M15.75 9.75h1.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
-              <path d="M15.75 12.25h1.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
-              <path d="M15.75 14.75h1.5" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" />
+            <svg class="news-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="4.25" y="5.5" width="13.5" height="12.5" rx="1.6" ry="1.6" />
+              <path d="M18.75 7.5h.75c.97 0 1.75.78 1.75 1.75v7c0 1.1-.9 2-2 2H18" />
+              <path d="M7.5 9.75h4.5" />
+              <path d="M7.5 12.25h6.5" />
+              <path d="M7.5 14.75h6.5" />
+              <path d="M15.75 9.75h1.5" />
+              <path d="M15.75 12.25h1.5" />
+              <path d="M15.75 14.75h1.5" />
             </svg>
           </button>
           <div id="newsPop" class="news-pop hidden" role="dialog" aria-label="News">

--- a/index.html
+++ b/index.html
@@ -603,7 +603,7 @@ Check back later for updates.</div>
     const dlPop = el('dlPop');
     const dlWin = el('dlWin');
     const WINDOWS_LINK_SOURCES = [
-      'https://raw.githubusercontent.com/PixelArchitectureStudio/ScaleConverter/main/windows.txt',
+      'https://github.com/PixelArchitectureStudio/ScaleConverter/blob/main/windows.txt?raw=1',
       'windows.txt'
     ];
     let windowsLinkOverride = null;

--- a/index.html
+++ b/index.html
@@ -110,6 +110,9 @@
     .news-close{background:none;border:none;color:inherit;cursor:pointer;font-size:18px;line-height:1;padding:0 4px;display:inline-flex;align-items:center;justify-content:center;border-radius:6px}
     .news-close:hover{background:rgba(122,162,255,0.12)}
     .news-body{font-size:13px;color:var(--text);white-space:pre-line}
+    .news-body.loading{display:flex;align-items:center;gap:8px;color:var(--muted)}
+    .news-body.loading::before{content:'';width:12px;height:12px;border-radius:50%;border:2px solid currentColor;border-top-color:var(--accent);animation:news-spin .8s linear infinite;flex-shrink:0}
+    @keyframes news-spin{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}
 
     @media (max-width:680px){
       .news-pop{width:90%;max-width:calc(100vw - 48px)}
@@ -142,6 +145,7 @@
     body.light .news-pop{background:#ffffff;border-color:#cbd5e1;box-shadow:0 10px 30px rgba(0,0,0,.12)}
     body.light .news-head{color:#64748b}
     body.light .news-body{color:#0d1220}
+    body.light .news-body.loading{color:#64748b}
     body.light .news-close:hover{background:rgba(122,162,255,0.16)}
 
     
@@ -581,6 +585,12 @@ Check back later for updates.</div>
     const NEWS_SOURCE = 'news.txt';
     let newsContentOverride = null;
     let newsFetchPromise = null;
+
+    function setNewsBody(text, isLoading){
+      if (!newsBody) return;
+      newsBody.textContent = typeof text === 'string' ? text : '';
+      newsBody.classList.toggle('loading', !!isLoading);
+    }
     const calcBtn = el('calcBtn');
     const versionBtn = el('versionBtn');
     const verPop = el('verPop');
@@ -677,6 +687,7 @@ Check back later for updates.</div>
         newsDialogLabel: 'خبرهای جدید',
         newsHeading: 'خبرها',
         newsCloseLabel: 'بستن خبرها',
+        newsLoading: 'در حال بارگذاری خبرها…',
         newsEmpty: 'در حال حاضر خبری در دسترس نیست.\nبرای به‌روزرسانی‌ها بعداً سر بزنید.',
         detailHeading: 'جزئیات مبدل:',
         footerCredit: 'ساخته شده توسط <strong>Pixel Studio</strong>',
@@ -748,6 +759,7 @@ Check back later for updates.</div>
         newsDialogLabel: 'News updates',
         newsHeading: 'News',
         newsCloseLabel: 'Close news',
+        newsLoading: 'Loading news…',
         newsEmpty: 'No news available right now.\nCheck back later for updates.',
         detailHeading: 'Converter details:',
         footerCredit: 'Built by <strong>Pixel Studio</strong>',
@@ -978,8 +990,13 @@ Check back later for updates.</div>
       if (newsPop) newsPop.setAttribute('aria-label', locale.newsDialogLabel);
       if (newsTitle) newsTitle.textContent = locale.newsHeading;
       if (newsBody){
-        newsBody.textContent = locale.newsEmpty;
-        if (newsContentOverride) newsBody.textContent = newsContentOverride;
+        if (newsContentOverride){
+          setNewsBody(newsContentOverride, false);
+        } else if (newsFetchPromise){
+          setNewsBody(locale.newsLoading, true);
+        } else {
+          setNewsBody(locale.newsEmpty, false);
+        }
       }
       if (newsClose) newsClose.setAttribute('aria-label', locale.newsCloseLabel);
       if (dlBtn) dlBtn.setAttribute('title', locale.downloadTitle);
@@ -1193,8 +1210,16 @@ Check back later for updates.</div>
     }
     async function ensureNewsContent(){
       if (!newsBody || newsContentOverride) return Promise.resolve();
-      if (newsFetchPromise) return newsFetchPromise;
-      if (typeof fetch !== 'function') return Promise.resolve();
+      const locale = getLocale();
+      if (newsFetchPromise){
+        setNewsBody(locale.newsLoading, true);
+        return newsFetchPromise;
+      }
+      if (typeof fetch !== 'function'){
+        setNewsBody(locale.newsEmpty, false);
+        return Promise.resolve();
+      }
+      setNewsBody(locale.newsLoading, true);
       const cacheBuster = Date.now().toString(36);
       newsFetchPromise = fetch(`${NEWS_SOURCE}?v=${cacheBuster}`, { cache: 'no-store' })
         .then(async function(res){
@@ -1206,14 +1231,19 @@ Check back later for updates.</div>
           return text.length ? text : null;
         })
         .then(function(content){
+          const activeLocale = getLocale();
           if (content){
             newsContentOverride = content;
-            newsBody.textContent = content;
-            requestAnimationFrame(positionNewsPopover);
+            setNewsBody(content, false);
+          } else {
+            setNewsBody(activeLocale.newsEmpty, false);
           }
+          requestAnimationFrame(positionNewsPopover);
         })
         .catch(function(err){
           console.warn(err);
+          setNewsBody(getLocale().newsEmpty, false);
+          requestAnimationFrame(positionNewsPopover);
         })
         .finally(function(){
           if (!newsContentOverride) newsFetchPromise = null;

--- a/index.html
+++ b/index.html
@@ -1209,17 +1209,20 @@ Check back later for updates.</div>
       newsPop.style.transform = 'none';
     }
     async function ensureNewsContent(){
-      if (!newsBody || newsContentOverride) return Promise.resolve();
+      if (!newsBody) return Promise.resolve();
       const locale = getLocale();
       if (newsFetchPromise){
         setNewsBody(locale.newsLoading, true);
+        requestAnimationFrame(positionNewsPopover);
         return newsFetchPromise;
       }
       if (typeof fetch !== 'function'){
         setNewsBody(locale.newsEmpty, false);
+        requestAnimationFrame(positionNewsPopover);
         return Promise.resolve();
       }
       setNewsBody(locale.newsLoading, true);
+      requestAnimationFrame(positionNewsPopover);
       const cacheBuster = Date.now().toString(36);
       newsFetchPromise = fetch(`${NEWS_SOURCE}?v=${cacheBuster}`, { cache: 'no-store' })
         .then(async function(res){
@@ -1236,21 +1239,27 @@ Check back later for updates.</div>
             newsContentOverride = content;
             setNewsBody(content, false);
           } else {
+            newsContentOverride = null;
             setNewsBody(activeLocale.newsEmpty, false);
           }
           requestAnimationFrame(positionNewsPopover);
         })
         .catch(function(err){
           console.warn(err);
-          setNewsBody(getLocale().newsEmpty, false);
+          const activeLocale = getLocale();
+          if (newsContentOverride){
+            setNewsBody(newsContentOverride, false);
+          } else {
+            setNewsBody(activeLocale.newsEmpty, false);
+          }
           requestAnimationFrame(positionNewsPopover);
         })
         .finally(function(){
-          if (!newsContentOverride) newsFetchPromise = null;
+          newsFetchPromise = null;
         });
       return newsFetchPromise;
     }
-    function toggleNews(show){ if (!newsPop || !newsBtn) return; const open = !newsPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('news'); newsPop.classList.remove('hidden'); newsBtn.setAttribute('aria-expanded','true'); ensureNewsContent().finally(function(){ requestAnimationFrame(positionNewsPopover); }); } else { newsPop.classList.add('hidden'); newsBtn.setAttribute('aria-expanded','false'); newsPop.style.top=''; newsPop.style.left=''; newsPop.style.right=''; newsPop.style.transform=''; } }
+    function toggleNews(show){ if (!newsPop || !newsBtn) return; const open = !newsPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('news'); newsPop.classList.remove('hidden'); newsBtn.setAttribute('aria-expanded','true'); positionNewsPopover(); ensureNewsContent().finally(function(){ requestAnimationFrame(positionNewsPopover); }); } else { newsPop.classList.add('hidden'); newsBtn.setAttribute('aria-expanded','false'); newsPop.style.top=''; newsPop.style.left=''; newsPop.style.right=''; newsPop.style.transform=''; } }
     if (newsBtn){ newsBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleNews(); }); }
     if (newsClose){ newsClose.addEventListener('click', function(e){ e.stopPropagation(); toggleNews(false); }); }
     window.addEventListener('resize', positionNewsPopover);

--- a/index.html
+++ b/index.html
@@ -99,6 +99,22 @@
     .topbar{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
     .actions{display:flex;align-items:center;gap:10px}
     .icon-btn{width:32px;height:32px;display:inline-flex;align-items:center;justify-content:center;border-radius:10px;padding:0;font-size:16px}
+    .news-anchor{position:relative;display:inline-flex;align-items:center}
+    .news-btn{cursor:pointer;border:1px solid #2b3152;background:#0f1326;color:var(--text);border-radius:10px;width:32px;height:32px;padding:0;display:inline-flex;align-items:center;justify-content:center}
+    .news-btn:hover{filter:brightness(1.1)}
+    .news-icon{width:18px;height:18px;display:block}
+    .news-pop{position:absolute;top:calc(50% + 16px);left:calc(100% + 12px);right:auto;transform:translateY(-50%);background:#0f1326;border:1px solid #2b3152;border-radius:12px;width:220px;max-width:min(240px,calc(100vw - 48px));padding:12px;box-shadow:0 10px 30px rgba(0,0,0,.35);z-index:90}
+    .news-pop.hidden{display:none}
+    .news-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;font-size:12px;color:#94a3c7}
+    .news-title{font-weight:600;letter-spacing:.02em}
+    .news-close{background:none;border:none;color:inherit;cursor:pointer;font-size:18px;line-height:1;padding:0 4px;display:inline-flex;align-items:center;justify-content:center;border-radius:6px}
+    .news-close:hover{background:rgba(122,162,255,0.12)}
+    .news-body{font-size:13px;color:var(--text);white-space:pre-line}
+
+    @media (max-width:680px){
+      .news-anchor{position:static}
+      .news-pop{top:calc(100% + 8px);left:50%;transform:translate(-50%,0);right:auto}
+    }
     .lang-btn{min-width:60px;position:relative;cursor:pointer;border:1px solid #2b3152;background:#0f1326;color:var(--text);border-radius:999px;display:inline-flex;align-items:center;justify-content:center;height:28px;padding:0 14px;font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase}
     .lang-btn:hover{filter:brightness(1.1)}
     .lang-btn .lang-text{pointer-events:none}
@@ -123,6 +139,11 @@
     body.light .ig-link:hover{border-color:#3b82f6}
     body.light .switch{background:#ffffff;border-color:#cbd5e1;color:#0d1220}
     body.light .lang-btn{background:#ffffff;border-color:#cbd5e1;color:#0d1220}
+    body.light .news-btn{background:#ffffff;border-color:#cbd5e1;color:#0d1220}
+    body.light .news-pop{background:#ffffff;border-color:#cbd5e1;box-shadow:0 10px 30px rgba(0,0,0,.12)}
+    body.light .news-head{color:#64748b}
+    body.light .news-body{color:#0d1220}
+    body.light .news-close:hover{background:rgba(122,162,255,0.16)}
 
     
     .hist-pop{position:absolute; right:12px; top:100%; margin-top:8px; background:#0f1326; border:1px solid #2b3152; border-radius:12px; width:260px; padding:10px; box-shadow:0 10px 30px rgba(0,0,0,.35); z-index:70}
@@ -314,6 +335,19 @@
         <button id="langToggle" class="lang-btn" type="button" aria-label="تغییر زبان به انگلیسی" data-lang="fa">
           <span class="lang-text" id="langToggleText">فا</span>
         </button>
+        <div class="news-anchor">
+          <button id="newsBtn" class="icon-btn news-btn" type="button" aria-haspopup="dialog" aria-expanded="false" title="News">
+            <img src="news-icon.svg" alt="" class="news-icon" aria-hidden="true" />
+          </button>
+          <div id="newsPop" class="news-pop hidden" role="dialog" aria-label="News">
+            <div class="news-head">
+              <span id="newsTitle" class="news-title">News</span>
+              <button type="button" id="newsClose" class="news-close" aria-label="Close news">×</button>
+            </div>
+            <div id="newsBody" class="news-body">No news available right now.
+Check back later for updates.</div>
+          </div>
+        </div>
         <button id="themeToggle" class="switch" aria-label="تغییر حالت روشن/تاریک" data-mode="dark">
           <span class="icon sun" aria-hidden="true">☀️</span>
           <span class="icon moon" aria-hidden="true">🌙</span>
@@ -531,6 +565,11 @@
     const histPop = el('histPop');
     const histList = el('histList');
     const histClose = el('histClose');
+    const newsBtn = el('newsBtn');
+    const newsPop = el('newsPop');
+    const newsTitle = el('newsTitle');
+    const newsBody = el('newsBody');
+    const newsClose = el('newsClose');
     const calcBtn = el('calcBtn');
     const versionBtn = el('versionBtn');
     const verPop = el('verPop');
@@ -623,6 +662,11 @@
         copyButtonTitle: 'کپی مقدار',
         histButtonTitle: 'تاریخچه ۱۰ مقدار اخیر',
         swapButtonTitle: 'تبدیل جهت (نقشه ↔ واقعی)',
+        newsButtonTitle: 'خبرها',
+        newsDialogLabel: 'خبرهای جدید',
+        newsHeading: 'خبرها',
+        newsCloseLabel: 'بستن خبرها',
+        newsEmpty: 'در حال حاضر خبری در دسترس نیست.\nبرای به‌روزرسانی‌ها بعداً سر بزنید.',
         detailHeading: 'جزئیات مبدل:',
         footerCredit: 'ساخته شده توسط <strong>Pixel Studio</strong>',
         downloadLabel: 'دانلود',
@@ -689,6 +733,11 @@
         copyButtonTitle: 'Copy value',
         histButtonTitle: 'History (last 10 values)',
         swapButtonTitle: 'Swap direction (map ↔ real)',
+        newsButtonTitle: 'Latest news',
+        newsDialogLabel: 'News updates',
+        newsHeading: 'News',
+        newsCloseLabel: 'Close news',
+        newsEmpty: 'No news available right now.\nCheck back later for updates.',
         detailHeading: 'Converter details:',
         footerCredit: 'Built by <strong>Pixel Studio</strong>',
         downloadLabel: 'Download',
@@ -911,6 +960,14 @@
       if (downloadWeb) downloadWeb.textContent = locale.downloadWeb;
       if (downloadShare) downloadShare.textContent = locale.downloadShare;
       if (downloadWebHelp) downloadWebHelp.textContent = locale.downloadWebHelp;
+      if (newsBtn){
+        newsBtn.setAttribute('title', locale.newsButtonTitle);
+        newsBtn.setAttribute('aria-label', locale.newsButtonTitle);
+      }
+      if (newsPop) newsPop.setAttribute('aria-label', locale.newsDialogLabel);
+      if (newsTitle) newsTitle.textContent = locale.newsHeading;
+      if (newsBody) newsBody.textContent = locale.newsEmpty;
+      if (newsClose) newsClose.setAttribute('aria-label', locale.newsCloseLabel);
       if (dlBtn) dlBtn.setAttribute('title', locale.downloadTitle);
       if (dlPop) dlPop.setAttribute('aria-label', locale.downloadAria);
       if (converterForm) converterForm.setAttribute('aria-label', locale.formAriaLabel);
@@ -1081,13 +1138,16 @@
       }).join('');
     }
     function addToHistory(outText, meta){ if (!outText || outText==='—') return; const arr = readHistory(); if (arr.length && arr[0].out === outText) return; arr.unshift({out: outText, meta: meta||null, t: Date.now()}); writeHistory(arr); if (histPop && !histPop.classList.contains('hidden')) renderHistory(); lastSavedOut = outText; }
-    function closeOthers(except){ if (except!=='history') toggleHistory(false); if (except!=='version') toggleVersion(false); if (except!=='download') toggleDownload(false); }
+    function closeOthers(except){ if (except!=='history') toggleHistory(false); if (except!=='version') toggleVersion(false); if (except!=='download') toggleDownload(false); if (except!=='news') toggleNews(false); }
     function toggleHistory(show){ if (!histPop) return; const open = !histPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('history'); histPop.classList.remove('hidden'); renderHistory(); } else { histPop.classList.add('hidden'); } }
     if (histBtn){ histBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleHistory(); }); }
     if (histClose){ histClose.addEventListener('click', function(e){ e.stopPropagation(); toggleHistory(false); }); }
     function toggleVersion(show){ if (!verPop || !versionBtn) return; const open = !verPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('version'); verPop.classList.remove('hidden'); versionBtn.setAttribute('aria-expanded','true'); } else { verPop.classList.add('hidden'); versionBtn.setAttribute('aria-expanded','false'); } }
     if (versionBtn){ versionBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleVersion(); }); }
     function toggleDownload(show){ if (!dlPop || !dlBtn) return; const open = !dlPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('download'); dlPop.classList.remove('hidden'); dlBtn.setAttribute('aria-expanded','true'); } else { dlPop.classList.add('hidden'); dlBtn.setAttribute('aria-expanded','false'); } }
+    function toggleNews(show){ if (!newsPop || !newsBtn) return; const open = !newsPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('news'); newsPop.classList.remove('hidden'); newsBtn.setAttribute('aria-expanded','true'); } else { newsPop.classList.add('hidden'); newsBtn.setAttribute('aria-expanded','false'); } }
+    if (newsBtn){ newsBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleNews(); }); }
+    if (newsClose){ newsClose.addEventListener('click', function(e){ e.stopPropagation(); toggleNews(false); }); }
     if (dlBtn){ dlBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleDownload(); }); }
     if (dlWin){
       dlWin.addEventListener('click', function(e){
@@ -1155,9 +1215,13 @@
       if (verPop && !verPop.classList.contains('hidden')){
         if (!(verPop.contains(e.target) || (versionBtn && versionBtn.contains(e.target)))) toggleVersion(false);
       }
+      // Close news popover if click is outside
+      if (newsPop && !newsPop.classList.contains('hidden')){
+        if (!(newsPop.contains(e.target) || (newsBtn && newsBtn.contains(e.target)))) toggleNews(false);
+      }
     });
 
-    document.addEventListener('keydown', function(e){ if (e.key === 'Escape'){ toggleHistory(false); toggleVersion(false); toggleDownload(false); } });
+    document.addEventListener('keydown', function(e){ if (e.key === 'Escape'){ toggleHistory(false); toggleVersion(false); toggleDownload(false); toggleNews(false); } });
 
     window.addEventListener('resize', scheduleScrollLockUpdate);
     window.addEventListener('orientationchange', scheduleScrollLockUpdate);

--- a/index.html
+++ b/index.html
@@ -603,11 +603,46 @@ Check back later for updates.</div>
     const dlPop = el('dlPop');
     const dlWin = el('dlWin');
     const WINDOWS_LINK_SOURCES = [
-      'https://github.com/PixelArchitectureStudio/ScaleConverter/blob/main/windows.txt?raw=1',
+      'https://github.com/PixelArchitectureStudio/ScaleConverter/blob/main/windows.txt',
       'windows.txt'
     ];
     let windowsLinkOverride = null;
     let windowsFetchPromise = null;
+    function normalizeRemoteTextSource(src){
+      if (!src || typeof src !== 'string') return src;
+      const trimmed = src.trim();
+      if (!trimmed) return trimmed;
+      if (!/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmed)){
+        return trimmed;
+      }
+      try {
+        const parsed = new URL(trimmed);
+        const host = parsed.hostname.toLowerCase();
+        if (host === 'github.com'){
+          const segments = parsed.pathname.split('/').filter(Boolean);
+          const blobIndex = segments.indexOf('blob');
+          if (blobIndex !== -1){
+            const rawSegments = segments.slice(0, blobIndex).concat(segments.slice(blobIndex + 1));
+            const params = new URLSearchParams(parsed.search);
+            params.delete('raw');
+            const query = params.toString();
+            const rawUrl = `https://raw.githubusercontent.com/${rawSegments.join('/')}`;
+            return query ? `${rawUrl}?${query}` : rawUrl;
+          }
+        }
+        if (host === 'raw.githubusercontent.com'){
+          const params = new URLSearchParams(parsed.search);
+          if (params.has('raw')){
+            params.delete('raw');
+            const query = params.toString();
+            return `${parsed.origin}${parsed.pathname}${query ? `?${query}` : ''}`;
+          }
+        }
+        return parsed.toString();
+      } catch(err){
+        return trimmed;
+      }
+    }
     const dlWebLink = el('dlWeb');
     const dlShareBtn = el('dlShareBtn');
     const langToggle = el('langToggle');
@@ -1202,8 +1237,10 @@ Check back later for updates.</div>
       function fetchWindowsFromSource(index){
         if (index >= WINDOWS_LINK_SOURCES.length) return Promise.reject(new Error('Windows link unavailable'));
         const src = WINDOWS_LINK_SOURCES[index];
-        const separator = src.includes('?') ? '&' : '?';
-        return fetch(`${src}${separator}v=${cacheBuster}`, { cache: 'no-store' })
+        const normalizedSrc = normalizeRemoteTextSource(src) || src;
+        const urlToFetch = typeof normalizedSrc === 'string' ? normalizedSrc : String(normalizedSrc || '');
+        const separator = urlToFetch.includes('?') ? '&' : '?';
+        return fetch(`${urlToFetch}${separator}v=${cacheBuster}`, { cache: 'no-store' })
           .then(async function(res){
             if (!res.ok){
               const error = new Error(`Windows link fetch failed: ${res.status}`);
@@ -1297,8 +1334,10 @@ Check back later for updates.</div>
       function fetchFromSource(index){
         if (index >= NEWS_SOURCES.length) return Promise.reject(new Error('News unavailable'));
         const src = NEWS_SOURCES[index];
-        const separator = src.includes('?') ? '&' : '?';
-        return fetch(`${src}${separator}v=${cacheBuster}`, { cache: 'no-store' })
+        const normalizedSrc = normalizeRemoteTextSource(src) || src;
+        const urlToFetch = typeof normalizedSrc === 'string' ? normalizedSrc : String(normalizedSrc || '');
+        const separator = urlToFetch.includes('?') ? '&' : '?';
+        return fetch(`${urlToFetch}${separator}v=${cacheBuster}`, { cache: 'no-store' })
           .then(async function(res){
             if (!res.ok){
               const error = new Error(`News fetch failed: ${res.status}`);

--- a/index.html
+++ b/index.html
@@ -578,6 +578,9 @@ Check back later for updates.</div>
     const newsTitle = el('newsTitle');
     const newsBody = el('newsBody');
     const newsClose = el('newsClose');
+    const NEWS_SOURCE = 'news.txt';
+    let newsContentOverride = null;
+    let newsFetchPromise = null;
     const calcBtn = el('calcBtn');
     const versionBtn = el('versionBtn');
     const verPop = el('verPop');
@@ -974,7 +977,10 @@ Check back later for updates.</div>
       }
       if (newsPop) newsPop.setAttribute('aria-label', locale.newsDialogLabel);
       if (newsTitle) newsTitle.textContent = locale.newsHeading;
-      if (newsBody) newsBody.textContent = locale.newsEmpty;
+      if (newsBody){
+        newsBody.textContent = locale.newsEmpty;
+        if (newsContentOverride) newsBody.textContent = newsContentOverride;
+      }
       if (newsClose) newsClose.setAttribute('aria-label', locale.newsCloseLabel);
       if (dlBtn) dlBtn.setAttribute('title', locale.downloadTitle);
       if (dlPop) dlPop.setAttribute('aria-label', locale.downloadAria);
@@ -1185,7 +1191,36 @@ Check back later for updates.</div>
       newsPop.style.right = 'auto';
       newsPop.style.transform = 'none';
     }
-    function toggleNews(show){ if (!newsPop || !newsBtn) return; const open = !newsPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('news'); newsPop.classList.remove('hidden'); newsBtn.setAttribute('aria-expanded','true'); requestAnimationFrame(positionNewsPopover); } else { newsPop.classList.add('hidden'); newsBtn.setAttribute('aria-expanded','false'); newsPop.style.top=''; newsPop.style.left=''; newsPop.style.right=''; newsPop.style.transform=''; } }
+    async function ensureNewsContent(){
+      if (!newsBody || newsContentOverride) return Promise.resolve();
+      if (newsFetchPromise) return newsFetchPromise;
+      if (typeof fetch !== 'function') return Promise.resolve();
+      const cacheBuster = Date.now().toString(36);
+      newsFetchPromise = fetch(`${NEWS_SOURCE}?v=${cacheBuster}`, { cache: 'no-store' })
+        .then(async function(res){
+          if (!res.ok){
+            if (res.status === 404) return null;
+            throw new Error(`News fetch failed: ${res.status}`);
+          }
+          const text = (await res.text()).replace(/\r\n/g, '\n').trim();
+          return text.length ? text : null;
+        })
+        .then(function(content){
+          if (content){
+            newsContentOverride = content;
+            newsBody.textContent = content;
+            requestAnimationFrame(positionNewsPopover);
+          }
+        })
+        .catch(function(err){
+          console.warn(err);
+        })
+        .finally(function(){
+          if (!newsContentOverride) newsFetchPromise = null;
+        });
+      return newsFetchPromise;
+    }
+    function toggleNews(show){ if (!newsPop || !newsBtn) return; const open = !newsPop.classList.contains('hidden'); const willOpen = (typeof show==='boolean') ? show : !open; if (willOpen){ closeOthers('news'); newsPop.classList.remove('hidden'); newsBtn.setAttribute('aria-expanded','true'); ensureNewsContent().finally(function(){ requestAnimationFrame(positionNewsPopover); }); } else { newsPop.classList.add('hidden'); newsBtn.setAttribute('aria-expanded','false'); newsPop.style.top=''; newsPop.style.left=''; newsPop.style.right=''; newsPop.style.transform=''; } }
     if (newsBtn){ newsBtn.addEventListener('click', function(e){ e.stopPropagation(); toggleNews(); }); }
     if (newsClose){ newsClose.addEventListener('click', function(e){ e.stopPropagation(); toggleNews(false); }); }
     window.addEventListener('resize', positionNewsPopover);

--- a/news-icon.svg
+++ b/news-icon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title>News icon</title>
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5c2aff"/>
+      <stop offset="100%" stop-color="#a855f7"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#g)"/>
+  <rect x="14" y="16" width="36" height="6" rx="3" fill="rgba(255,255,255,0.75)"/>
+  <rect x="14" y="26" width="22" height="6" rx="3" fill="rgba(255,255,255,0.85)"/>
+  <rect x="14" y="36" width="28" height="6" rx="3" fill="rgba(255,255,255,0.65)"/>
+  <rect x="14" y="46" width="18" height="6" rx="3" fill="rgba(255,255,255,0.5)"/>
+  <path d="M42 31l8-7v18l-8-7v-4z" fill="#f1f5ff"/>
+</svg>

--- a/news-icon.svg
+++ b/news-icon.svg
@@ -1,15 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#7aa2ff" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" role="img" aria-labelledby="title">
   <title>News icon</title>
-  <defs>
-    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#5c2aff"/>
-      <stop offset="100%" stop-color="#a855f7"/>
-    </linearGradient>
-  </defs>
-  <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#g)"/>
-  <rect x="14" y="16" width="36" height="6" rx="3" fill="rgba(255,255,255,0.75)"/>
-  <rect x="14" y="26" width="22" height="6" rx="3" fill="rgba(255,255,255,0.85)"/>
-  <rect x="14" y="36" width="28" height="6" rx="3" fill="rgba(255,255,255,0.65)"/>
-  <rect x="14" y="46" width="18" height="6" rx="3" fill="rgba(255,255,255,0.5)"/>
-  <path d="M42 31l8-7v18l-8-7v-4z" fill="#f1f5ff"/>
+  <rect x="4.25" y="5.5" width="13.5" height="12.5" rx="1.6" ry="1.6" />
+  <path d="M18.75 7.5h.75c.97 0 1.75.78 1.75 1.75v7c0 1.1-.9 2-2 2H18" />
+  <path d="M7.5 9.75h4.5" />
+  <path d="M7.5 12.25h6.5" />
+  <path d="M7.5 14.75h6.5" />
+  <path d="M15.75 9.75h1.5" />
+  <path d="M15.75 12.25h1.5" />
+  <path d="M15.75 14.75h1.5" />
 </svg>

--- a/windows.txt
+++ b/windows.txt
@@ -1,0 +1,1 @@
+https://github.com/PixelArchitectureStudio/ScaleConverter/releases/download/v1.4/ScaleConverter_Win64.exe


### PR DESCRIPTION
## Summary
- replace the news popover empty copy with the requested placeholder message in both locales
- preserve newline formatting in the news panel body so the placeholder renders on two lines

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ea01d07fec832886e1f156d21cb6cc